### PR TITLE
商品詳細のサーバーサイド実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,8 +10,8 @@
 // @import "footer"; 
 @import "./modules/main-visual"; 
 @import "./modules/products"; 
-@import "mypage-side";
-@import "mypage-main";
+@import "./modules/product-show"; 
+
 @import "./modules/logout";
 @import "./modules/card";
 @import "font-awesome-sprockets";

--- a/app/assets/stylesheets/modules/_product-show.scss
+++ b/app/assets/stylesheets/modules/_product-show.scss
@@ -113,6 +113,18 @@ body {
     -webkit-transition: all ease-out .3s;
     transition: all ease-out .3s;
   }
+  .disabeled-btn {
+    background: gray;
+    display: block;
+    font-size: 24px;
+    line-height: 60px;
+    margin-top: 16px;
+    color: #fff;
+    text-align: center;
+    font-weight: 600;
+    -webkit-transition: all ease-out .3s;
+    transition: all ease-out .3s;
+  }
   .product-description {
     padding: 32px 0 0;
     line-height: 1.5;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,4 @@
 class ProductsController < ApplicationController
-  # before_action :move_to_index, except: :index
 
   def index
     @product = Product.all
@@ -12,16 +11,12 @@ class ProductsController < ApplicationController
   def buy
   end
 
-  def destroy
-    item = Item.find(params[:id])
-    if item.user_id == current_user.id
-      item.destroy
-      redirect_to("/")
-    end
-  end
-
-  private
-  # def move_to_index
-  #   redirect_to action: :index unless user_signed_in?
+  # def destroy
+  #   item = Item.find(params[:id])
+  #   if item.user_id == current_user.id
+  #     item.destroy
+  #     redirect_to("/")
+  #   end
   # end
+
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -6,7 +6,7 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @product = Product.find(params[:id])
+    @product = Product.find{params[:id]}
   end
 
   def buy

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :move_to_index, except: :index
+  # before_action :move_to_index, except: :index
 
   def index
     @product = Product.all
@@ -21,7 +21,7 @@ class ProductsController < ApplicationController
   end
 
   private
-  def move_to_index
-    redirect_to action: :index unless user_signed_in?
-  end
+  # def move_to_index
+  #   redirect_to action: :index unless user_signed_in?
+  # end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -6,6 +6,7 @@ class ProductsController < ApplicationController
   end
 
   def show
+    @product = Product.find(params[:id])
   end
 
   def buy

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -95,7 +95,7 @@
       .products__heading レディース新着アイテム
       .products__more_btn もっと見る ＞
     .product
-      = link_to "#", class: "product__flex" do
+      = link_to product_path(@product), class: "product__flex" do
         - @product.each do |product|
           .product__flex__list
             = image_tag product.images.first.image, alt: "test", class: "product__flex__list__image"

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -2,16 +2,20 @@
 
 %section.products-container
   %h1.products-name
-    aaaaaaaaaaaaaaa
+    = @product.title
   .product-content.clearfix
     .product-content__photo
+      = image_tag @product.images.first.image, alt: "test", class: "product-content__photo"
+      -if @product.buyer_id.present? 
+        .product__flex__list__image__sold
+          .product__flex__list__image__sold__inner SOLD
     %table.product-content__detail
       %tbody
         %tr
           %th 出品者
           %td 
             = link_to "#" do
-              name
+              = @product.seller.nickname
             .item-user-raitings
               %i.fas.fa-grin
               %span 100
@@ -35,28 +39,47 @@
           %td ブランドA
         %tr
           %th 商品の状態
-          %td 新品、未使用
+          %td
+            = @product.status
         %tr
           %th 配送料の負担
-          %td 着払い(購入者負担)
+          %td
+            = @product.delivery_person
         %tr
           %th 配送の方法
-          %td 普通郵便(定形、定形外)
+          %td
+            = @product.delivery_way
         %tr
           %th 発送元地域
-          %td 大阪府
+          %td
+            = @product.from_area
         %tr
           %th 発送日の目安
-          %td 2~3日で発送
+          %td
+            = @product.delivery_leadtime
   .product-price.text-center
-    %span.product-price__tag.bold ¥10,000
+    %span.product-price__tag.bold
+      ¥ #{@product.price}
     %span.product-price__tax  (税込)
-    %span.product-price__fee 送料込み
-  = link_to "#", class: "product-buy-btn" do
-    購入画面に進む
+    %span.product-price__fee
+      = @product.delivery_person
+  - if user_signed_in? && current_user.id == @product.seller.id
+    = link_to "#", class: "product-buy-btn" do
+      編集する
+    = link_to "#", class: "product-buy-btn" do
+      削除する
+  - elsif user_signed_in? && current_user.id != @product.seller.id
+    = link_to "#", class: "product-buy-btn" do
+      購入画面に進む
+  - elsif @product.buyer_id.present?
+    = link_to "#", class: "disabeled-btn"
+    売り切れました
+  - else
+    = link_to new_user_registration_path, class: "product-buy-btn" do
+      購入画面に進む
   .product-description
-    %p.product-description__text こんにちはこんにちはこんにちはこんにちはこんにちはこんにちは
-    こんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちはこんにちは
+    %p.product-description__text
+      = @product.introduction
   .product-button
     .product-button__left
       %button.btn.liked
@@ -80,162 +103,10 @@
         %button.comment-submit
           %span コメントする
 
-.products-another
-  %section.products-another__container.clearfix
-    %h2.products-another__container__head
-      = link_to "#" do
-        userさんのその他の出品
-    .products-another__container__content.clearfix
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
+= render "layouts/footer-publicity" 
+= render "layouts/footer-introduction" 
+= render "layouts/bottom-camera" 
 
-  %section.products-another__container.clearfix
-    %h2.products-another__container__head
-      = link_to "#" do
-        カテゴリー その他の出品
-    .products-another__container__content.clearfix
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
-      %section.products-box
-        = link_to "#" do
-          .products-box__photo
-            = image_tag "/"
-          .products-box__body
-            .products-box__body__name
-              another-item-name
-            .products-box__body__num
-              .products-box__body__num__price ¥5,000
-              .products-box__body__num__liked-count
-                %i.fas.fa-star.like-icon
-                %span 99
 
 = render "layouts/footer-publicity" 
 = render "layouts/footer-introduction" 

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -63,20 +63,22 @@
     %span.product-price__tax  (税込)
     %span.product-price__fee
       = @product.delivery_person
+
   - if user_signed_in? && current_user.id == @product.seller.id
     = link_to "#", class: "product-buy-btn" do
       編集する
     = link_to "#", class: "product-buy-btn" do
       削除する
+  - elsif @product.buyer_id.present?
+    = link_to "#", class: "disabeled-btn" do
+      売り切れました
   - elsif user_signed_in? && current_user.id != @product.seller.id
     = link_to "#", class: "product-buy-btn" do
       購入画面に進む
-  - elsif @product.buyer_id.present?
-    = link_to "#", class: "disabeled-btn"
-    売り切れました
   - else
     = link_to new_user_session_path, class: "product-buy-btn" do
       購入画面に進む
+      
   .product-description
     %p.product-description__text
       = @product.introduction

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -107,9 +107,3 @@
 = render "layouts/footer-introduction" 
 = render "layouts/bottom-camera" 
 
-
-= render "layouts/footer-publicity" 
-= render "layouts/footer-introduction" 
-= render "layouts/bottom-camera" 
-
-

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -75,7 +75,7 @@
     = link_to "#", class: "disabeled-btn"
     売り切れました
   - else
-    = link_to new_user_registration_path, class: "product-buy-btn" do
+    = link_to new_user_session_path, class: "product-buy-btn" do
       購入画面に進む
   .product-description
     %p.product-description__text

--- a/app/views/users/_mypage-main.html.haml
+++ b/app/views/users/_mypage-main.html.haml
@@ -2,7 +2,8 @@
   %section.mypage-user
     = link_to "#" do
       .avatar
-      %h2 user-name
+      %h2
+        = current_user.nickname
       .mypage-user__number
         %div 
           評価 

--- a/app/views/users/logout_page.html.haml
+++ b/app/views/users/logout_page.html.haml
@@ -5,7 +5,8 @@
     %form.logout
       .logout__box
         %button.logout__box__btn
-          ログアウト
+          = link_to destroy_session_path, method: :delete do
+            ログアウト
 
 = render "layouts/footer-publicity" 
 = render "layouts/footer-introduction" 

--- a/app/views/users/logout_page.html.haml
+++ b/app/views/users/logout_page.html.haml
@@ -5,7 +5,7 @@
     %form.logout
       .logout__box
         %button.logout__box__btn
-          = link_to destroy_session_path, method: :delete do
+          = link_to destroy_user_session_path, method: :delete do
             ログアウト
 
 = render "layouts/footer-publicity" 


### PR DESCRIPTION
# What
一覧ページから画像クリックで遷移するページ。遷移後、DBから値を取得、表示させる。
購入などのボタンは条件分岐によって表示内容を変更。
ログアウト状態でも商品詳細ページに遷移できるようにmove_indexのbefore actionは削除。

# Why
必須項目