### PR TITLE
商品購入機能の実装漏れに対する修正対応

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :set_product, except: [:index, :new, :create,:get_category_children, :get_category_grandchildren]
+  before_action :set_product, except: [:index, :new, :create, :pay, :get_category_children, :get_category_grandchildren]
 
   require 'payjp'
 
@@ -80,6 +80,11 @@ class ProductsController < ApplicationController
     customer: card.customer_id,
     currency: 'jpy',
     )
+    # 購入履歴を残す
+    purchase_history = Product.find(params[:id])
+    purchase_history.buyer_id = current_user.id
+    purchase_history.save
+
     redirect_to root_path
   end
 

--- a/app/views/products/buy.html.haml
+++ b/app/views/products/buy.html.haml
@@ -8,7 +8,7 @@
       .item-inner
         .item-inner__mask
           .item-inner__mask__image
-            = image_tag @image[:image], alt: "test", width: "80", height: "80"
+            = image_tag @product.images.first.image.to_s, alt: "test", width: "80", height: "80"
         .item-info
           %p.item-name
             = @product[:title]

--- a/app/views/products/buy.html.haml
+++ b/app/views/products/buy.html.haml
@@ -51,6 +51,7 @@
     .purchase-container__content__box
       = form_tag(action: :pay, method: :post) do
         = text_field_tag :buy_price, @product[:price], { type: "hidden", class: "text" }
+        = text_field_tag :id, @product[:id], { type: "hidden", class: "text" }
         - if card_info == false
           = button_tag '購入する', type: 'submit', class: 'buy-button', disabled: true
         - else

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -86,7 +86,7 @@
     = link_to "#", class: "disabeled-btn" do
       売り切れました
   - elsif user_signed_in? && current_user.id != @product.seller.id
-    = link_to "#", class: "product-buy-btn" do
+    = link_to buy_product_path(@product), class: "product-buy-btn" do
       購入画面に進む
   - else
     = link_to new_user_session_path, class: "product-buy-btn" do


### PR DESCRIPTION
# What
商品詳細画面から購入ボタン押下時に商品購入画面へ遷移するよう修正対応を行う
購入履歴が残るよう修正対応を行う

# Why
商品詳細画面からの遷移先の指定がなかったため
誰が購入したかデータ登録の記述がなかったため